### PR TITLE
Add some attributes to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,6 @@
+author = Thomas Klausner <domm@plix.at>
 name    = Plack-Middleware-PrettyException
 copyright_year   = 2016 - 2021
+copyright_holder = Thomas Klausner
 
 [@Author::DOMM]


### PR DESCRIPTION
Adds `author` and `copyright_holder` attributes to `dist.ini`. If these are missing when running `dzil build`, `Dist::Zilla::Plugin::PodWeaver` will use the values in `~/dzil/config.ini` when creating the pod document.

If the user does not have a `~/dzil/config.ini`, `dzil build` will fail. On the other hand if the user happens to have a `~/dzil/config.ini`, the Pod document will then be converted to a `README.md` file in the root directory by the plugin `Dist::Zilla::Plugin::ReadmeAnyFromPod`. The problem is that this `README.md` is part of the GitHub repository's tracked files and it would then be somewhat inconvenient for other users than the author of this module to submit changes to `README.md`. They would then first have to revert the changes to the AUTHOR and "COPYRIGHT AND LICENSE" sections in `README.md` made by `dzil build` before changing the file (as part of a potential pull request).

Alternatively, if they do not run `dzil build` the reasoning above does not really apply. But I think running `dzil build` or `dzil test` is something one often will do before submitting a PR.

_[[Assigned by [pullrequest.club](https://pullrequest.club)]]_